### PR TITLE
Guessed facade should be in a module

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@ class MypageController < ApplicationController
   end
 
   def messages
-    # You can retrieve data from the guessed facade
+    # コントローラとアクション名前から推測されたFacadeからデータを取得することが可能
     # MyPageController#notifications => MyPage::NotificationsFacade
     payload = { current_user: current_user }
     retrieve_from(payload, :messages)

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,6 +39,18 @@ class Mypage::IndexFacade < ApplicationFacade
   end
 end
 
+class MyPage::NotificationsFacade < ApplicationFacade
+  attr_reader :current_user
+
+  def initialize(payload)
+    @current_user = payload[:current_user]
+  end
+
+  def messages
+    @messages ||= current_user.messages.order(created_at: :desc).limit(10)
+  end
+end
+
 class MypageController < ApplicationController
   # #retrieveメソッドを使用するために必要
   include ActionFacade::Retrieval
@@ -47,6 +59,13 @@ class MypageController < ApplicationController
     facade = Mypage::IndexFacade.new(current_user: current_user)
     # インスタンス変数をアサインする
     retrieve(facade, :active_users, :messages)
+  end
+
+  def messages
+    # You can retrieve data from the guessed facade
+    # MyPageController#notifications => MyPage::NotificationsFacade
+    payload = { current_user: current_user }
+    retrieve_from(payload, :messages)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ class Mypage::IndexFacade < ApplicationFacade
   end
 end
 
+class MyPage::NotificationsFacade < ApplicationFacade
+  attr_reader :current_user
+
+  def initialize(payload)
+    @current_user = payload[:current_user]
+  end
+
+  def messages
+    @messages ||= current_user.messages.order(created_at: :desc).limit(10)
+  end
+end
+
 class MypageController < ApplicationController
   # for using #retrieve method
   include ActionFacade::Retrieval
@@ -49,6 +61,13 @@ class MypageController < ApplicationController
     facade = Mypage::IndexFacade.new(current_user: current_user)
     # assign instance variables
     retrieve(facade, :active_users, :messages)
+  end
+
+  def messages
+    # You can retrieve data from the guessed facade
+    # MyPageController#notifications => MyPage::NotificationsFacade
+    payload = { current_user: current_user }
+    retrieve_from(payload, :messages)
   end
 end
 ```

--- a/actionfacade/lib/action_facade/retrieval.rb
+++ b/actionfacade/lib/action_facade/retrieval.rb
@@ -58,7 +58,7 @@ module ActionFacade
       klass_name = self.class.name
       if klass_name.end_with?("Controller")
         if defined?(params) && params[:action]
-          klass_name.delete_suffix("Controller") + params[:action].camelize + "Facade"
+          klass_name.delete_suffix("Controller") + "::#{params[:action].camelize}Facade"
         else
           klass_name.delete_suffix("Controller") + "Facade"
         end

--- a/actionfacade/test/retrieval_test.rb
+++ b/actionfacade/test/retrieval_test.rb
@@ -10,9 +10,11 @@ class UsersFacade < ActionFacade::Base
   end
 end
 
-class AdminsShowFacade < ActionFacade::Base
-  def bob
-    USER_DATA.find { |user| user[:name] == "bob" }
+module Admin
+  class ShowFacade < ActionFacade::Base
+    def bob
+      USER_DATA.find { |user| user[:name] == "bob" }
+    end
   end
 end
 
@@ -33,7 +35,7 @@ class UsersController
   end
 end
 
-class AdminsController
+class AdminController
   include ActionFacade::Retrieval
 
   attr_reader :bob
@@ -70,7 +72,7 @@ class RetrievalTest < Test::Unit::TestCase
   end
 
   test "@bob is set after retrieve_from(payload, :bob)" do
-    controller = AdminsController.new
+    controller = AdminController.new
     assert_nil(controller.bob)
     controller.show
     assert_equal(controller.bob, { id: 2, name: "bob" })


### PR DESCRIPTION
In order to tidy up `app/facades` directory, guessed facade should be in a module by controller.

For the facade used in `MyPageController#notifications`, suggested class name will be `MyPage::NotificationsFacade`

```ruby
class MyPage::NotificationsFacade < ApplicationFacade
  attr_reader :current_user

  def initialize(payload)
    @current_user = payload[:current_user]
  end

  def messages
    @messages ||= current_user.messages.order(created_at: :desc).limit(10)
  end
end

class MypageController < ApplicationController
  include ActionFacade::Retrieval

  def messages
    # You can retrieve data from the guessed facade
    # MyPageController#notifications => MyPage::NotificationsFacade
    payload = { current_user: current_user }
    retrieve_from(payload, :messages)
  end
end
```